### PR TITLE
Print filtered gists with highlights conditional on included content

### DIFF
--- a/pkg/cmd/gist/list/list.go
+++ b/pkg/cmd/gist/list/list.go
@@ -262,15 +262,23 @@ func highlightMatch(s string, filter *regexp.Regexp, matched *bool, color, highl
 	}
 
 	out := strings.Builder{}
+
+	// Color up to the first match. If an empty string, no ANSI color sequence is added.
 	if _, err := out.WriteString(color(s[:matches[0][0]])); err != nil {
 		return "", err
 	}
 
-	for _, match := range matches {
+	// Highlight each match, then color the remaining text which, if an empty string, no ANSI color sequence is added.
+	for i, match := range matches {
 		if _, err := out.WriteString(highlight(s[match[0]:match[1]])); err != nil {
 			return "", err
 		}
-		if _, err := out.WriteString(color(s[match[1]:])); err != nil {
+
+		text := s[match[1]:]
+		if i+1 < len(matches) {
+			text = s[match[1]:matches[i+1][0]]
+		}
+		if _, err := out.WriteString(color(text)); err != nil {
 			return "", nil
 		}
 	}

--- a/pkg/cmd/gist/list/list_test.go
+++ b/pkg/cmd/gist/list/list_test.go
@@ -648,3 +648,59 @@ func Test_listRun(t *testing.T) {
 		})
 	}
 }
+
+func Test_highlightMatch(t *testing.T) {
+	regex := regexp.MustCompilePOSIX(`[Oo]cto`)
+	tests := []struct {
+		name  string
+		input string
+		color bool
+		want  string
+	}{
+		{
+			name:  "single match",
+			input: "Octo",
+			want:  "Octo",
+		},
+		{
+			name:  "single match (color)",
+			input: "Octo",
+			color: true,
+			want:  "\x1b[0;30;43mOcto\x1b[0m",
+		},
+		{
+			name:  "single match with extra",
+			input: "Hello, Octocat!",
+			want:  "Hello, Octocat!",
+		},
+		{
+			name:  "single match with extra (color)",
+			input: "Hello, Octocat!",
+			color: true,
+			want:  "\x1b[0;34mHello, \x1b[0m\x1b[0;30;43mOcto\x1b[0m\x1b[0;34mcat!\x1b[0m",
+		},
+		{
+			name:  "multiple matches",
+			input: "Octocat/octo",
+			want:  "Octocat/octo",
+		},
+		{
+			name:  "multiple matches (color)",
+			input: "Octocat/octo",
+			color: true,
+			want:  "\x1b[0;30;43mOcto\x1b[0m\x1b[0;34mcat/\x1b[0m\x1b[0;30;43mocto\x1b[0m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := iostreams.NewColorScheme(tt.color, false, false)
+
+			matched := false
+			got, err := highlightMatch(tt.input, regex, &matched, cs.Blue, cs.Highlight)
+			assert.NoError(t, err)
+			assert.True(t, matched)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -143,7 +143,7 @@ func displayResults(io *iostreams.IOStreams, results search.CodeResult) error {
 			}
 			fmt.Fprintf(io.Out, "%s %s\n", cs.Blue(code.Repository.FullName), cs.GreenBold(code.Path))
 			for _, match := range code.TextMatches {
-				lines := formatMatch(match.Fragment, match.Matches, io.ColorEnabled())
+				lines := formatMatch(match.Fragment, match.Matches, io)
 				for _, line := range lines {
 					fmt.Fprintf(io.Out, "\t%s\n", strings.TrimSpace(line))
 				}
@@ -153,7 +153,7 @@ func displayResults(io *iostreams.IOStreams, results search.CodeResult) error {
 	}
 	for _, code := range results.Items {
 		for _, match := range code.TextMatches {
-			lines := formatMatch(match.Fragment, match.Matches, io.ColorEnabled())
+			lines := formatMatch(match.Fragment, match.Matches, io)
 			for _, line := range lines {
 				fmt.Fprintf(io.Out, "%s:%s: %s\n", cs.Blue(code.Repository.FullName), cs.GreenBold(code.Path), strings.TrimSpace(line))
 			}
@@ -162,7 +162,9 @@ func displayResults(io *iostreams.IOStreams, results search.CodeResult) error {
 	return nil
 }
 
-func formatMatch(t string, matches []search.Match, colorize bool) []string {
+func formatMatch(t string, matches []search.Match, io *iostreams.IOStreams) []string {
+	cs := io.ColorScheme()
+
 	startIndices := map[int]struct{}{}
 	endIndices := map[int]struct{}{}
 	for _, m := range matches {
@@ -186,14 +188,10 @@ func formatMatch(t string, matches []search.Match, colorize bool) []string {
 			continue
 		}
 		if _, ok := startIndices[i]; ok {
-			if colorize {
-				b.WriteString("\x1b[30;43m") // black text on yellow background
-			}
+			b.WriteString(cs.HighlightStart()) // black text on yellow background
 			found = true
 		} else if _, ok := endIndices[i]; ok {
-			if colorize {
-				b.WriteString("\x1b[m") // color reset
-			}
+			b.WriteString(cs.Reset()) // color reset
 		}
 		b.WriteRune(c)
 	}

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -8,6 +8,10 @@ import (
 	"github.com/mgutz/ansi"
 )
 
+const (
+	highlightStyle = "black:yellow"
+)
+
 var (
 	magenta            = ansi.ColorFunc("magenta")
 	cyan               = ansi.ColorFunc("cyan")
@@ -20,6 +24,8 @@ var (
 	bold               = ansi.ColorFunc("default+b")
 	cyanBold           = ansi.ColorFunc("cyan+b")
 	greenBold          = ansi.ColorFunc("green+b")
+	highlightStart     = ansi.ColorCode(highlightStyle)
+	highlight          = ansi.ColorFunc(highlightStyle)
 
 	gray256 = func(t string) string {
 		return fmt.Sprintf("\x1b[%d;5;%dm%s\x1b[m", 38, 242, t)
@@ -174,6 +180,30 @@ func (c *ColorScheme) FailureIcon() string {
 
 func (c *ColorScheme) FailureIconWithColor(colo func(string) string) string {
 	return colo("X")
+}
+
+func (c *ColorScheme) HighlightStart() string {
+	if !c.enabled {
+		return ""
+	}
+
+	return highlightStart
+}
+
+func (c *ColorScheme) Highlight(t string) string {
+	if !c.enabled {
+		return t
+	}
+
+	return highlight(t)
+}
+
+func (c *ColorScheme) Reset() string {
+	if !c.enabled {
+		return ""
+	}
+
+	return ansi.Reset
 }
 
 func (c *ColorScheme) ColorFromString(s string) func(string) string {


### PR DESCRIPTION
When `--filter` is passed, matches will be highlighted in the existing table. If file names match, the "n file(s)" cell will be highlighted.

When `--include-content` is additionally passed, the file name, description, and/or content will be printed like `search code` with matches highlighted.